### PR TITLE
Add backward compatibility to Image object.

### DIFF
--- a/pygeobase/object_base.py
+++ b/pygeobase/object_base.py
@@ -80,7 +80,7 @@ class Image(object):
     The Image class represents the base object of an image.
     """
 
-    def __init__(self, lon, lat, data, metadata, timestamp, timekey='jd'):
+    def __init__(self, lon, lat, data, metadata, timestamp, timekey=None):
         """
         Initialization of the image object.
 
@@ -106,3 +106,16 @@ class Image(object):
         self.metadata = metadata
         self.timestamp = timestamp
         self.timekey = timekey
+
+    def __iter__(self):
+        l = [self.data, self.metadata,
+             self.timestamp, self.lon,
+             self.lat]
+
+        if self.timekey is not None:
+            l.append(self.data[self.timekey])
+        else:
+            l.append(None)
+
+        for attr in l:
+            yield attr

--- a/tests/test_object_base.py
+++ b/tests/test_object_base.py
@@ -1,0 +1,54 @@
+from pygeobase.object_base import Image
+from datetime import datetime
+import numpy as np
+import numpy.testing as nptest
+
+
+def test_tuple_unpacking():
+    lon = np.array([1, 2, 3])
+    lat = np.array([1, 2, 3])
+    data = {'variable': np.array([1, 2, 3]),
+            'jd': np.array([5, 6, 7])}
+    metadata = {'attribute': 'test'}
+    timestamp = datetime(2000, 1, 1, 12)
+    img = Image(lon, lat, data, metadata, timestamp, timekey='jd')
+
+    (return_data,
+     return_metadata,
+     return_timestamp,
+     return_lon,
+     return_lat,
+     times) = img
+
+    for key in data:
+        nptest.assert_allclose(return_data[key], data[key])
+    assert return_metadata == metadata
+    assert return_timestamp == timestamp
+    nptest.assert_allclose(return_lon, lon)
+    nptest.assert_allclose(return_lat, lat)
+    nptest.assert_allclose(times, data['jd'])
+
+
+def test_tuple_unpacking_no_timekey():
+    lon = np.array([1, 2, 3])
+    lat = np.array([1, 2, 3])
+    data = {'variable': np.array([1, 2, 3]),
+            'jd': np.array([5, 6, 7])}
+    metadata = {'attribute': 'test'}
+    timestamp = datetime(2000, 1, 1, 12)
+    img = Image(lon, lat, data, metadata, timestamp)
+
+    (return_data,
+     return_metadata,
+     return_timestamp,
+     return_lon,
+     return_lat,
+     times) = img
+
+    for key in data:
+        nptest.assert_allclose(return_data[key], data[key])
+    assert return_metadata == metadata
+    assert return_timestamp == timestamp
+    nptest.assert_allclose(return_lon, lon)
+    nptest.assert_allclose(return_lat, lat)
+    assert times is None


### PR DESCRIPTION
This adds backward compatibility to the Image object.

@christophreimer I changed the default timekey from 'jd' to None. Would that break something you know of?