### PR TITLE
Fix passing of keyword arguments in MultiTemporalImageBase.

### DIFF
--- a/pygeobase/io_base.py
+++ b/pygeobase/io_base.py
@@ -870,10 +870,10 @@ class MultiTemporalImageBase(object):
         img: object
             pygeobase.object_base.Image object
         """
-        filepath = self._build_filename(timestamp, **kwargs)
+        filepath = self._build_filename(timestamp)
         img = None
 
-        if self._open(filepath, **kwargs):
+        if self._open(filepath):
             kwargs['timestamp'] = timestamp
             if mask is False:
                 img = self.fid.read(**kwargs)

--- a/tests/test_io_base.py
+++ b/tests/test_io_base.py
@@ -1,6 +1,10 @@
 import pygeogrids.grids as grids
 import numpy as np
+from datetime import datetime
 from pygeobase.io_base import GriddedTsBase
+from pygeobase.io_base import ImageBase
+from pygeobase.io_base import MultiTemporalImageBase
+from pygeobase.object_base import Image
 
 
 class TestDataset(object):
@@ -40,3 +44,46 @@ def test_gridded_ts_base_iter_ts():
     gpi_should = [4, 3, 1, 2]
     for ts, gpi in ds.iter_ts():
         assert gpi == gpi_should.pop(0)
+
+
+class TestImageDataset(ImageBase):
+
+    def read(self, timestamp=None, additional_kw=None):
+
+        return Image(None, None, None, {'kw': additional_kw}, timestamp)
+
+    def write(self, data):
+        raise NotImplementedError()
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class TestMultiTemporalImageDataset(MultiTemporalImageBase):
+
+    def __init__(self):
+        super(TestMultiTemporalImageDataset,
+              self).__init__("", TestImageDataset)
+
+
+def test_multi_temp_dataset():
+    ds = TestMultiTemporalImageDataset()
+
+    data = ds.read(datetime(2000, 1, 1))
+
+    assert type(data) == Image
+    assert data.timestamp == datetime(2000, 1, 1)
+    assert data.metadata == {'kw': None}
+
+
+def test_multi_temp_dataset_kw_passing():
+    ds = TestMultiTemporalImageDataset()
+
+    data = ds.read(datetime(2000, 1, 1), additional_kw="test")
+
+    assert type(data) == Image
+    assert data.timestamp == datetime(2000, 1, 1)
+    assert data.metadata == {'kw': "test"}


### PR DESCRIPTION
@christophreimer @sebhahn Was there any reason why the kwargs would be needed in `_build_filename` or `_open`