### PR TITLE
Resample interface and image compability

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.3.12
+==============
+
+- change ``resample_data`` interface to get weights directly instead of windowRadius.
+- Add ``dtype`` and ``__getitem__`` to ``Image`` class.
+
 Version 0.3.11
 ==============
 

--- a/pygeobase/object_base.py
+++ b/pygeobase/object_base.py
@@ -132,7 +132,7 @@ class Image(object):
         numpy array.
         """
         dtype_list = []
-        for key in list(self.data.iterkeys()):
+        for key in self.data:
             dtype_list.append((key, self.data[key].dtype.type))
 
         return np.dtype(dtype_list)

--- a/pygeobase/object_base.py
+++ b/pygeobase/object_base.py
@@ -25,6 +25,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import numpy as np
+
 
 class TS(object):
     """
@@ -121,3 +123,16 @@ class Image(object):
 
         for attr in l:
             yield attr
+
+    @property
+    def dtype(self):
+        """
+        Fake numpy recarray dtype field based
+        on the dictionary keys and the dtype of the
+        numpy array.
+        """
+        dtype_list = []
+        for key in list(self.data.iterkeys()):
+            dtype_list.append((key, self.data[key].dtype.type))
+
+        return np.dtype(dtype_list)

--- a/pygeobase/object_base.py
+++ b/pygeobase/object_base.py
@@ -132,7 +132,7 @@ class Image(object):
         numpy array.
         """
         dtype_list = []
-        for key in self.data:
+        for key in sorted(list(self.data)):
             dtype_list.append((key, self.data[key].dtype.type))
 
         return np.dtype(dtype_list)

--- a/pygeobase/object_base.py
+++ b/pygeobase/object_base.py
@@ -136,3 +136,6 @@ class Image(object):
             dtype_list.append((key, self.data[key].dtype.type))
 
         return np.dtype(dtype_list)
+
+    def __getitem__(self, key):
+        return self.data[key]

--- a/tests/test_object_base.py
+++ b/tests/test_object_base.py
@@ -65,3 +65,15 @@ def test_dtype_property():
     assert np.dtype([('variable', np.int16), ('jd', np.float32)]) == img.dtype
     assert list(img.dtype.fields) == ['variable', 'jd']
     assert img.dtype.names == ('variable', 'jd')
+
+
+def test_getitem():
+    lon = np.array([1, 2, 3], dtype=np.float32)
+    lat = np.array([1, 2, 3], dtype=np.float32)
+    data = {'variable': np.array([1, 2, 3], dtype=np.int16),
+            'jd': np.array([5, 6, 7], dtype=np.float32)}
+    metadata = {'attribute': 'test'}
+    timestamp = datetime(2000, 1, 1, 12)
+    img = Image(lon, lat, data, metadata, timestamp, timekey='jd')
+    nptest.assert_allclose(img['jd'], data['jd'])
+    nptest.assert_allclose(img['variable'], data['variable'])

--- a/tests/test_object_base.py
+++ b/tests/test_object_base.py
@@ -62,9 +62,9 @@ def test_dtype_property():
     metadata = {'attribute': 'test'}
     timestamp = datetime(2000, 1, 1, 12)
     img = Image(lon, lat, data, metadata, timestamp, timekey='jd')
-    assert np.dtype([('variable', np.int16), ('jd', np.float32)]) == img.dtype
-    assert list(img.dtype.fields) == ['variable', 'jd']
-    assert img.dtype.names == ('variable', 'jd')
+    assert np.dtype([('jd', np.float32), ('variable', np.int16)]) == img.dtype
+    assert sorted(list(img.dtype.fields)) == ['jd', 'variable']
+    assert img.dtype.names == ('jd', 'variable')
 
 
 def test_getitem():

--- a/tests/test_object_base.py
+++ b/tests/test_object_base.py
@@ -52,3 +52,16 @@ def test_tuple_unpacking_no_timekey():
     nptest.assert_allclose(return_lon, lon)
     nptest.assert_allclose(return_lat, lat)
     assert times is None
+
+
+def test_dtype_property():
+    lon = np.array([1, 2, 3], dtype=np.float32)
+    lat = np.array([1, 2, 3], dtype=np.float32)
+    data = {'variable': np.array([1, 2, 3], dtype=np.int16),
+            'jd': np.array([5, 6, 7], dtype=np.float32)}
+    metadata = {'attribute': 'test'}
+    timestamp = datetime(2000, 1, 1, 12)
+    img = Image(lon, lat, data, metadata, timestamp, timekey='jd')
+    assert np.dtype([('variable', np.int16), ('jd', np.float32)]) == img.dtype
+    assert list(img.dtype.fields) == ['variable', 'jd']
+    assert img.dtype.names == ('variable', 'jd')


### PR DESCRIPTION
- fix/improve #34 
- Make image class look like a numpy.recarray from the outside by supporting a dtype and a `__getitem__` method.
- Improve resample_data documentation and interface.