### PR TITLE
Replace read_ts with read

### DIFF
--- a/src/pygeobase/io_base.py
+++ b/src/pygeobase/io_base.py
@@ -649,7 +649,7 @@ class GriddedTsBase(GriddedBase):
         data = None
 
         if self._open(gp):
-            data = self.fid.read_ts(gp, **kwargs)
+            data = self.fid.read(gp, **kwargs)
 
         return data
 


### PR DESCRIPTION
Found another case of the old `read_ts` method in the package itself. Replace it with `read`.